### PR TITLE
Feature: Proxy

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type CliOptions struct {
 	ConfigFile    string
 	Cookies       string
 	Headers       string
+	Proxy         string
 	Debug         bool
 	Concurrency   int
 	DecodedParams bool
@@ -40,10 +41,10 @@ func verifyFlags(options *CliOptions) error {
 	flag.StringVar(&options.ConfigFile, "config", "", "File path to config file, which contains fuzz rules")
 
 	flag.StringVar(&options.Cookies, "cookies", "", "Cookies to add in all requests")
-
 	flag.StringVar(&options.Headers, "H", "", "Headers to add in all requests. Multiple should be separated by semi-colon")
 	flag.StringVar(&options.Headers, "headers", "", "Headers to add in all requests. Multiple should be separated by semi-colon")
 
+	flag.StringVar(&options.Proxy, "proxy", "", "set proxy url example: http://127.0.0.1:8080")
 	flag.BoolVar(&options.Debug, "debug", false, "Debug/verbose mode to print more info for failed/malformed URLs or requests")
 
 	flag.BoolVar(&options.SilentMode, "s", false, "Only print successful evaluations (i.e. mute status updates). Note these updates print to stderr, and won't be saved if saving stdout to files")

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,37 @@
+rules:
+  XssDetection:
+    description: This rule checks for reflected parameters
+    injections:
+      - '"><h2>asd</h2>'
+      - <asd>test</asd>
+    expectation:
+      responseContents:
+        - <h2>asd</h2>
+        - <asd>test</asd>
+      responseHeaders:
+        Content-Type: html
+rules:
+  CallbackFuzz:
+    description: Test for open redirects and potential SSRFs by checking for certain responses or callbacks to your server
+    extraParams:
+      - url
+      - redirect_url
+    injections:
+      - "http://[[domain]].example.net/"
+      - "//example.net?targetUrl=[[fullurl]]"
+      - "https://example.net?target=[[domain]][[path]]"
+      - "@example.net"
+    expectation:
+      responseContents:
+        - Example Domain
+SqlInjectionCheck:
+  description: Test for potential SQL injections by injecting characters to break SQL statements
+  injections:
+    - "[[originalvalue]]'"
+  expectation:
+    responseCodes:
+      - 500
+  heuristics:
+    injection: "[[originalvalue]]''"
+    baselineMatches:
+      - "responseCode"

--- a/httpUtils.go
+++ b/httpUtils.go
@@ -3,8 +3,10 @@ package main
 import (
 	"crypto/tls"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/EDDYCJY/fake-useragent"
@@ -20,6 +22,15 @@ func createClient() {
 		}).DialContext,
 	}
 
+	if len(opts.Proxy) > 0 {
+		proxyUrl, err := url.Parse(opts.Proxy)
+		if err != nil {
+			log.Fatalf("Error parsing proxy URL: %v", err)
+		}
+
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+
 	redirect := func(req *http.Request, via []*http.Request) error {
 		if opts.NoRedirects {
 			return http.ErrUseLastResponse
@@ -28,10 +39,11 @@ func createClient() {
 	}
 
 	httpClient := &http.Client{
-		Transport: transport,
+		Transport:     transport,
 		CheckRedirect: redirect,
-		Timeout:   time.Duration(opts.Timeout+3) * time.Second,
+		Timeout:       time.Duration(opts.Timeout+3) * time.Second,
 	}
+
 	config.httpClient = httpClient
 }
 

--- a/httpUtils.go
+++ b/httpUtils.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -23,11 +22,7 @@ func createClient() {
 	}
 
 	if len(opts.Proxy) > 0 {
-		proxyUrl, err := url.Parse(opts.Proxy)
-		if err != nil {
-			log.Fatalf("Error parsing proxy URL: %v", err)
-		}
-
+		proxyUrl, _ := url.Parse(opts.Proxy)
 		transport.Proxy = http.ProxyURL(proxyUrl)
 	}
 

--- a/main.go
+++ b/main.go
@@ -88,9 +88,10 @@ func main() {
 	}
 
 	if len(opts.Proxy) > 0 {
+		println(opts.Proxy)
 		_, err := url.Parse(opts.Proxy)
-		if err == nil {
-			fmt.Println("Proxy doesn't respect url format:", err)
+		if err != nil { // Only exit on actual parsing error
+			fmt.Println("Proxy doesn't respect URL format:", err)
 			os.Exit(1)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -87,6 +87,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if len(opts.Proxy) > 0 {
+		_, err := url.Parse(opts.Proxy)
+		if err == nil {
+			fmt.Println("Proxy doesn't respect url format:", err)
+			os.Exit(1)
+		}
+	}
+
 	urls, err := getUrlsFromFile()
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
This feature allow user to use http url proxy is required:

like that
qsfuzz -proxy http://127.0.0.1:8080  -config config.yaml

A input check is performed to ensure that the string adheres to the URL format.